### PR TITLE
Fix zip upload with directory structure

### DIFF
--- a/django_photo_gallery/app/admin.py
+++ b/django_photo_gallery/app/admin.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-  
+# -*- coding: utf-8 -*-
+import os
 import uuid
 import zipfile
 import django_photo_gallery.settings
@@ -26,10 +27,16 @@ class AlbumModelAdmin(admin.ModelAdmin):
             album = form.save(commit=False)
             album.modified = datetime.now()
             album.save()
-
+            import pdb; pdb.set_trace()
             if form.cleaned_data['zip'] != None:
                 zip = zipfile.ZipFile(form.cleaned_data['zip'])
                 for filename in sorted(zip.namelist()):
+
+                    # Short following portion get rif of zip structure
+                    test_filename = os.path.basename(filename)
+                    if not test_filename:
+                        continue
+
                     data = zip.read(filename)
                     contentfile = ContentFile(data)
 

--- a/django_photo_gallery/app/admin.py
+++ b/django_photo_gallery/app/admin.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-  
+# -*- coding: utf-8 -*-
+import os
 import uuid
 import zipfile
 import django_photo_gallery.settings
@@ -30,6 +31,11 @@ class AlbumModelAdmin(admin.ModelAdmin):
             if form.cleaned_data['zip'] != None:
                 zip = zipfile.ZipFile(form.cleaned_data['zip'])
                 for filename in sorted(zip.namelist()):
+
+                    file_name = os.path.basename(filename)
+                    if not file_name:
+                        continue
+
                     data = zip.read(filename)
                     contentfile = ContentFile(data)
 

--- a/django_photo_gallery/app/admin.py
+++ b/django_photo_gallery/app/admin.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-import os
+# -*- coding: utf-8 -*-  
 import uuid
 import zipfile
 import django_photo_gallery.settings
@@ -27,16 +26,10 @@ class AlbumModelAdmin(admin.ModelAdmin):
             album = form.save(commit=False)
             album.modified = datetime.now()
             album.save()
-            import pdb; pdb.set_trace()
+
             if form.cleaned_data['zip'] != None:
                 zip = zipfile.ZipFile(form.cleaned_data['zip'])
                 for filename in sorted(zip.namelist()):
-
-                    # Short following portion get rif of zip structure
-                    test_filename = os.path.basename(filename)
-                    if not test_filename:
-                        continue
-
                     data = zip.read(filename)
                     contentfile = ContentFile(data)
 


### PR DESCRIPTION
When zipping a directory, its structure is kept within the zip file. This fix prevent the directory structure